### PR TITLE
Docker Compose: Aggregate compose files with script

### DIFF
--- a/docker-compose.sh
+++ b/docker-compose.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+TMP_FILE=/tmp/docker-compose.$$.yaml
+
+finish() {
+  rm ${TMP_FILE} ${TMP_FILE}.tmp 2>/dev/null
+}
+
+trap finish EXIT
+
+compose-config() {
+  mv -f ${TMP_FILE} ${TMP_FILE}.tmp
+  docker-compose -f ${1} -f ${TMP_FILE}.tmp config >${TMP_FILE}
+
+  rm -f ${TMP_FILE}.tmp 2>/dev/null
+}
+
+args=()
+files=()
+
+while [ -n "$1" ]; do 
+  case "$1" in
+    -f)
+      shift; files+=($1)
+      ;;
+    *)
+      args+=($1)
+      ;;
+  esac
+  shift
+done
+
+echo 'version: "3.1"' >${TMP_FILE}
+
+for f in ${files[@]}; do
+  compose-config ${f}
+done
+
+docker-compose -f ${TMP_FILE} ${args[@]}
+exit $?


### PR DESCRIPTION
Script to run multiple compose files without having to fix relative paths.

Source: https://gist.github.com/Gems/a40d7eb45f46c82f990aa7e8845d7e7a

Usage:
```bash
$ chmod +x docker-compose.sh
$ ./docker-compose.sh \
    -f ./frontend/docker/docker-compose.yml \
    -f ./proxy/docker/docker-compose.yml \
    -p 016 up
```